### PR TITLE
Remove deprecated `bottle :unneeded` in formula `revolver.rb`

### DIFF
--- a/Formula/revolver.rb
+++ b/Formula/revolver.rb
@@ -3,7 +3,6 @@ class Revolver < Formula
   homepage "https://github.com/molovo/revolver"
   url "https://github.com/molovo/revolver/archive/v0.2.4.tar.gz"
   sha256 "1999fa96a89dbb8b052cd56a6a58df5b12125e43c562bebf22216549196eaca4"
-  bottle :unneeded
   def install
     bin.install "revolver"
     zsh_completion.install "revolver.zsh-completion" => "_revolver"


### PR DESCRIPTION
This pull request simply removes the deprecated `bottle :unneeded` formula entry, which was being used by this tap for the `revolver` formula (specifically, in [`Formula/revolver.rb` *on line* `6`](https://github.com/molovo/homebrew-revolver/blob/ab1c05e53c63275cb39143ffa2f036141a5d28e6/Formula/revolver.rb#L6)).

For additional information regarding the deprecation of `bottle :unneeded`, you may reference the following:
- Homebrew/brew#11239: 
  Removal of `bottle :unneeded` from the formula auditor module ([`Library/Homebrew/formula_auditor.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula_auditor.rb))

- Homebrew/brew#11622
  Removal of `bottle :unneeded` from the formula support module ([`Library/Homebrew/formula_support.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula_support.rb))

- Homebrew/homebrew-core#75943
  The central issue handling the combined tracking of other PRs removing `bottle :unneeded` from all core formulas.

While the above-described deprecation of `bottle :unneeded` **does not** currently cause `brew` to raise a halting error message or otherwise exit un-cleanly, and therefore your formula continues to install and function as intended, I suspect such a specification change will ultimately result in a critical exception at some point in the future; all formulas actively including `bottle :unneeded` should be fixed in a timely manner.

Regardless of this, I can unequivocally confirm that *the deprecation warning output by `brew` is, in and of itself, __extremely obnoxious to end-users__*; I submit that this singular fact alone is justifiable cause for expedient removal of the invalid formula entry in all offending taps.

The reason the existing deprecation warning is particularly obnoxious (and should warrant quick merger of PRs aiming to resolve it) is because calling almost any `brew` command, *even those that are __not__ performing any actions on the offending formula, nor otherwise related to, even tangentially, this specific **tap** (`molovo/homebrew-revolver`) or this specific **formula** (`revolver`)*, still results in the display of the following **warning** message (an issue made exponentially worse by the fact that this verbose message is *repeated for every single tap containing any similarly offending formulas*):

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the molovo/revolver tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/molovo/homebrew-revolver/Formula/revolver.rb:6
```

For the collective sanity of `brew` end-users like myself, *please merge this as quickly as possible* and eliminate *one* of the warning messages output by `brew` (on every invocation) for many end-users; I am similarly providing PRs to other taps containing formulas using this deprecated entry and am hopeful that the aforementioned warning messages will ultimately decrement in quantity to zero over the next few weeks. I cannot wait for the day `brew` stops spamming me every time it is called... :-)

Verbose tongue-in-cheek commentary aside, I do appreciate your time and consideration regarding the review, acceptance, and merger of this PR.

Thanks; all the best!